### PR TITLE
add link to new mod1 exercises

### DIFF
--- a/module1/index.md
+++ b/module1/index.md
@@ -12,3 +12,4 @@ subheading: Fundamentals of Programming
 
 
 ## Other Resources
+- [Mod 1 Exercises](https://github.com/turingschool-examples/se-mod1-exercises)


### PR DESCRIPTION
# Curriculum PR Template

### Does this PR close any issues?
*This PR links #45 *

### Description
* Adds link to new Mod1 Exercises Repo
* Does NOT update links in existing lessons - since folks are already working on some lessons, trying to avoid merge conflicts.

### What questions do you have/what do you want feedback on? (optional)
* Double check that all references to the backend program have been removed from the exercises.  
* there are some resources that Josh Cheek has created that reference the backend program that we don't have full control over - do we think we should remove those, or leave as-is?  I'm leaning toward leave as-is for now at least.
