### PR TITLE
Add TBD for SE1 projects

### DIFF
--- a/module1/projects/index.md
+++ b/module1/projects/index.md
@@ -4,16 +4,17 @@ title: Module 1 - Projects
 ---
 
 ## Required Projects
-The following projects will be assigned and their completion is required to be promoted to module 2.
+The following projects will be assigned and their completion is required to be promoted to module 2.  
+The project specs will be linked below as each project is assigned.
 
 
 <!-- Week 1 (Ungraded): [Credit Check](./credit_check.markdown)-->
 <!-- Alternate between Flash Cards and War or Peace for repeaters -->
 <!-- Week 1-2 (Solo): [War or Peace](./war_or_peace/)-->
-- Week 1-2 (Solo) <!--: [Flash Cards](./flashcards/) -->
-- Week 2-3 (Solo): <!--[DMV](./dmv/)-->
+- Week 1-2 (Solo): TBD <!--: [Flash Cards](./flashcards/) -->
+- Week 2-3 (Solo): TBD <!--[DMV](./dmv/)-->
 <!-- Option to add more advanced option with Connect Four as other pair project -->
 <!-- - Week 3-4 (Paired): [Battleship](./battleship/) or [Connect Four)(./connect_four) -->
-- Week 3-4 (Paired): <!-- [Battleship](./battleship/)-->
-- Week 5-6 (Group Final): <!--[Futbol](./futbol_pd/) -->
+- Week 3-4 (Paired): TBD <!-- [Battleship](./battleship/)-->
+- Week 5-6 (Group Final): TBD <!--[Futbol](./futbol_pd/) -->
 


### PR DESCRIPTION
# Curriculum PR Template

Simply adds "TBD" to project page to avoid confusion since projects will not be posted until they're kicked off.