### PR TITLE
File io and Mocks and Stub Additional Repo link corrections

### DIFF
--- a/module1/lessons/file_io.md
+++ b/module1/lessons/file_io.md
@@ -191,4 +191,4 @@ function formatRowData(row) {
 ### Practice
 
 1. On your own, try reading the file and creating magical pet objects.
-1. Head over to the [event_manager directory]((https://github.com/turingschool-examples/se-mod1-exercises/tree/main/lessons/csv_files/event_manager)) in your "big repo".  Read through the overview in the README, then follow the instructions in the `exercise.md` file. This [Event Manager Lesson](https://curriculum.turing.edu/module1/projects/event_manager) will provide a more detailed walkthrough. 
+1. Head over to the [event_manager directory](https://github.com/turingschool-examples/se-mod1-exercises/tree/main/lessons/csv_files/event_manager) in your "big repo".  Read through the overview in the README, then follow the instructions in the `exercise.md` file. This [Event Manager Lesson](https://curriculum.turing.edu/module1/projects/event_manager) will provide a more detailed walkthrough. 

--- a/module1/lessons/file_io.md
+++ b/module1/lessons/file_io.md
@@ -157,7 +157,7 @@ end
 
 ### File I/O in JavaScript
 
-Reading from and writing to files in Javascript is very similar to the process we just covered in Ruby! There is a ['File system'](https://nodejs.org/api/fs.html#file-system) module in Node.js. This module is very versatile and allows for interaction with more file types than just CSVs.
+We'll be working in Ruby, but reading from and writing to files in Javascript is very similar to the process we just covered! There is a ['File system'](https://nodejs.org/api/fs.html#file-system) module in Node.js. This module is very versatile and allows for interaction with more file types than just CSVs.
 
 <section class="dropdown">
 
@@ -191,4 +191,4 @@ function formatRowData(row) {
 ### Practice
 
 1. On your own, try reading the file and creating magical pet objects.
-1. Head over to the "big repo" and find the `event_manager` directory. It can be found under `../mod-1-be-exercises/lessons/csv_files/event_manager`. Follow the instructions in the `exercise.md` file. The Readme will also provide some additional information.
+1. Head over to the [event_manager directory]((https://github.com/turingschool-examples/se-mod1-exercises/tree/main/lessons/csv_files/event_manager)) in your "big repo".  Read through the overview in the README, then follow the instructions in the `exercise.md` file. This [Event Manager Lesson](https://curriculum.turing.edu/module1/projects/event_manager) will provide a more detailed walkthrough. 

--- a/module1/lessons/mocks_stubs.md
+++ b/module1/lessons/mocks_stubs.md
@@ -186,6 +186,10 @@ What are mocks and stubs? When would you use them?
 Mocks and Stubs aren’t exclusive to Ruby, several languages including JavaScript use them too!
 </section>
 
+### More Practice
+
+How could mocks and stubs be used in your DMV project? Take a look at [this repo](https://github.com/turingschool-examples/mocks-and-stubs-dmv) to see how they are used to mock network calls made to retrieve facility information! We will revisit this topic in Mod 3. 
+
 ## Further Reading
 
 * Martin Fowler - Test Double: link [here](http://www.martinfowler.com/bliki/TestDouble.html)


### PR DESCRIPTION
# Curriculum PR Template

### Does this PR close any issues?
*This PR closes #109.

### Description
-  Moves the Event Manager lesson to SE Curriculum.  Includes link in the File IO lesson rather than the calendar (no ticket for this).
- Moves DMV repo with mocks and stubs example to turingschool -examples and links in Mocks and Stubs lesson instead of calendar.

### What questions do you have/what do you want feedback on? (optional)
*Does the duplicated repo look correct?  For FE repos you always have to run `npm install` when you clone one down so that is typically listed in the README.  For a BE repo, would you need to run `bundle` to install all the gems and dependencies?  Should we add that step to the README?
