### PR TITLE
Update set list to be API only, and update lesson links

### DIFF
--- a/module2/lessons/class_vs_instance_methods.md
+++ b/module2/lessons/class_vs_instance_methods.md
@@ -12,7 +12,7 @@ layout: page
 
 ## Set Up
 
-This lesson plan starts with the `class-vs-instance-setup` branch of our good old Set List Tutorial Repo. Get it [here](https://github.com/turingschool-examples/set-list-7/tree/class-vs-instance-setup). Then, follow the normal setup tasks:
+This lesson plan starts with the `class-vs-instance-methods-setup` branch of our good old Set List Tutorial Repo. Get it [here](https://github.com/turingschool-examples/set-list-api/tree/class-vs-instance-methods-setup). Then, follow the normal setup tasks:
 
 - Run `bundle install`
 - Run `rails db:{drop,create,migrate,seed}`
@@ -59,7 +59,7 @@ Using model tests and the corresponding models only, write methods that will:
 - Return a list of songs that have a title that contains the word "love"
 - Return the 3 songs that have the most plays, a length greater than `x` where `x` can be any integer value, and were updated within the last three days
 
-Answers to these practice problems can be found on the `class-vs-instance-solutions` branch [here](https://github.com/turingschool-examples/set-list-7/tree/class-vs-instance-solutions).
+Answers to these practice problems can be found on the `class-vs-instance-complete` branch [here](https://github.com/turingschool-examples/set-list-api/tree/class-vs-instance-complete).
 
 ## Checks for Understanding
 Answer the following questions either in your notebook or by taking [this review quiz](https://forms.gle/BG6JfUSAhSioYero6).

--- a/module2/lessons/intro_to_class_methods.md
+++ b/module2/lessons/intro_to_class_methods.md
@@ -3,7 +3,7 @@ title: Intro to Class Methods (in Rails)
 length: 45
 layout: page
 ---
-
+<!-- Archived Class? -->
 ## Learning Goals
 
 - Review Class Methods in Ruby

--- a/module2/lessons/joins.md
+++ b/module2/lessons/joins.md
@@ -11,13 +11,13 @@ title: Joins in SQL and Active Record
 
 ## Homework & Warm Up
 
-Before this class, try working through the directions in the README file of the [joins-homework](https://github.com/turingschool-examples/set-list-7/tree/joins-homework) branch in  Set List Tutorial. 
+Before this class, try working through the directions in the README file of the [joins-homework](https://github.com/turingschool-examples/set-list-api/tree/joins-homework) branch in  Set List Tutorial. 
 
-The 2nd part of the `joins-homework` exercises is to try some Join queries on your own, in the `spec/models/playlist_spec.rb` file. Reference this lesson for help writing AR Joins queries. 
+The 2nd part of the `joins-homework` exercises is to try some Join queries on your own, in the `spec/models/artist_spec.rb` file. Reference this lesson for help writing AR or SQL Joins queries. 
 
 ## Set Up
 
-For this lesson's code-along, you can start work from [this branch](https://github.com/turingschool-examples/set-list-7/tree/generic-start) of the Set List Tutorial.
+For this lesson's code-along, you can start work from the `joins-homework` branch of the Set List Tutorial.
 ```bash
 bundle install
 rails db:{drop,create,migrate,seed}
@@ -240,3 +240,6 @@ irb(main):001:0> Artist.joins(:songs).where('songs.length > ?', 400)
 
 ## Further Reading
 For an exploration of how to join multiple tables together, and advanced joining techniques, review the lesson [here](./joins_2).
+
+## Homework Solutions
+Check out [this branch](https://github.com/turingschool-examples/set-list-api/tree/joins-homework-solutions) to see solutions to the homework exercises.

--- a/module2/lessons/one_to_many_relationships_part2.md
+++ b/module2/lessons/one_to_many_relationships_part2.md
@@ -26,10 +26,10 @@ tags: migrations, databases, relationships, rails, activerecord
 
 ## Setup
 
-This lesson plan starts at the `associations-practice` branch of [this SetList repo](https://github.com/turingschool-examples/set-list-7/). In order to set up the app for this lesson:
+This lesson plan references our Set List Repo. For this first walkthrough, you can start at the `songs-index-complete` branch of [the repo](https://github.com/turingschool-examples/set-list-api/tree/songs-index-complete). In order to set up the app for this lesson:
 
 - Clone the repo
-- Checkout the `associations-practice` branch
+- Checkout the `songs-index-complete` branch
 - Run `bundle install`
 - Run `rails db:{drop,create,migrate,seed}`
 
@@ -455,4 +455,4 @@ Use TDD to create an instance method on our `Artist` model that returns the av
     - Add a reference from one table to another
     
 
-Completed code from this lesson plan can be found on this branch [here](https://github.com/turingschool-examples/set-list-7/tree/associations-practice-solutions\).
+Completed code from this walkthrough can be found on this branch [here](https://github.com/turingschool-examples/set-list-api/tree/associations-practice-setup). This branch also has some additional exercises designed for exploring ActiveRecord associations. Solutions for these exercises can be found [here.](https://github.com/turingschool-examples/set-list-api/tree/associations-practice-solutions)

--- a/module2/lessons/sql_and_active_record.md
+++ b/module2/lessons/sql_and_active_record.md
@@ -33,7 +33,7 @@ title: SQL and ActiveRecord
 
 ### Setup
 
-You can pull down the `sql-ar-setup` branch of our [Set List Tutorial repo](https://github.com/turingschool-examples/set-list-7/tree/sql-ar-setup).
+You can pull down the `sql-ar-setup` branch of our [Set List Tutorial repo](https://github.com/turingschool-examples/set-list-api/tree/sql-ar-setup).
 
 Make sure you start by running:
 


### PR DESCRIPTION
# Curriculum PR Template

### Does this PR close any issues?
Yes this PR closes #166 

### Description
- Create new API-only repo called Set List for Mod 2 classes: https://github.com/turingschool-examples/set-list-api/branches/active
- Port over/update the necessary exercises for the existing classes (classes that we're adding will add onto this repo)
- Update lesson links for the existing classes to point to exercises in this new repo
- Class list: SQL/AR basic, ActiveRecord Associations (One to Many pt2), Class Methods, Joins, Advanced Routing


### What questions do you have/what do you want feedback on? (optional)
Do you see any links I might have missed? If we had more time, it'd be great to try out all the exercises in each branch, but I think that would be tedious...
Does the Set List App look okay? Any branches we might be missing that *don't* have an upcoming lesson card associated?
