### PR TITLE
Update MVC lesson to point to completed task manager api

### DIFF
--- a/module2/lessons/intro_to_mvc.md
+++ b/module2/lessons/intro_to_mvc.md
@@ -20,8 +20,8 @@ title: Introduction to MVC
 
 ## Warmup
 
-- Open the Task Manager app you completed earlier in the inning. If you need a fresh copy of that application for any reason, a complete version can be found [here](https://github.com/turingschool-examples/task-manager-7-complete).
-<!-- TODO: Will need a complete version of this to link here -->
+- Open the Task Manager app you completed earlier in the inning. If you need a fresh copy of that application for any reason, a complete version can be found [here](https://github.com/turingschool-examples/task-manager-api).
+
 - In your own words, what are the primary responsibilities of the models, serializers, and controllers in Task Manager?
 
 ## Overview


### PR DESCRIPTION
# Curriculum PR Template

### Does this PR close any issues?
Yes this PR closes #174 

### Description
This new repo linked here is the finished code from the API Task Manager tutorial found here: https://github.com/turingschool-examples/se_task_manager_rails

### What questions do you have/what do you want feedback on? (optional)
I'm thinking maybe we should delete this repo which is a copy of the MVC Task Manager created for the SE program: https://github.com/turingschool-examples/task_manager_se
