### PR TITLE
Make json for api development public and change title of building apis

### DIFF
--- a/module2/lessons/building_an_api.md
+++ b/module2/lessons/building_an_api.md
@@ -1,5 +1,5 @@
 ---
-title: Intro to Building an API in Rails
+title: Building an API
 length: 120
 layout: page
 ---

--- a/module2/lessons/index.md
+++ b/module2/lessons/index.md
@@ -45,3 +45,4 @@ title: Module 2 - Lessons
 
 ## Additional Resources
 * [Chrome Dev Tools](./chrome_dev_tools)
+* [JSON for API development](../resources/json_for_api_development.md)


### PR DESCRIPTION
This PR doesn't close any ticket.

### Description
- Updates index.md to make the JSON for API development resource that @epintozzi brought over in [this closed PR](https://github.com/turingschool/curriculum-site/pull/178) viewable
- Changes title of Building an API lesson from `Intro to building a Rails API` to `Building an API` since there is already a separate Intro lesson. 
