### PR TITLE
Copy pd slide decks to SE drive and link in index

### DIFF
--- a/module2/lessons/index.md
+++ b/module2/lessons/index.md
@@ -48,10 +48,10 @@ title: Module 2 - Lessons
 ## Professional Development
 
 - [Overview](./pd_overview)
-- [Building Your Brand on LinkedIn](https://docs.google.com/presentation/d/e/2PACX-1vS8CZUjYkpnkTJrp2Ga8um-UUFUsJ-5JA85FF9x875J-l_eKy7IyL47sAt8kl_FOlg7rG5ntVxpk5he/pub?start=false&loop=false&delayms=3000)
+- [Building Your Brand on LinkedIn](https://docs.google.com/presentation/d/1dOrzlxTBowZfMYjl7fTx4qQSgLnWMekVwsorAtl-aaA/edit#slide=id.p1)
 - [Networking, Outreach and Coffee Chats](./networking)
-- [Networking](https://docs.google.com/presentation/d/e/2PACX-1vQa672IV-XwWG9q-ujEJ0w72QCBzf4jVMNI-trwLuKt9kk_ewe0l6Mk6YSWoo9UYMETbJ5RZ3akKyux/pub?start=false&loop=false&delayms=3000)
-- [Getting Job Hunt Ready](https://docs.google.com/presentation/d/e/2PACX-1vTDlRAiXiR_PSsAFGQtP8je_pcUWmLdk1kYc4jO4hTyzxDuksNWUMdUITMNXp1pRFMM0gKDiAVyXL0c/pub?start=false&loop=false&delayms=3000)
+- [Networking](https://docs.google.com/presentation/d/18ypIHjL-xh5906JslLJSmrEVx6liXw2lTliho3D42wI/edit?usp=sharing)
+- [Getting Job Hunt Ready](https://docs.google.com/presentation/d/1vYpy7tV5rQmYRV0jzxnfbhZsgF0VvptXyv7DxGAO8JY/edit?usp=sharing)
 
 ## Additional Resources
 


### PR DESCRIPTION
This PR will partially complete issue 194.

The 3 pd slide decks linked in the curriculum have been copied to the SE2 drive and the links have been updated. 