### PR TITLE
Update curriculum homepage/dr

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,4 @@
+<footer>
+  <p>Turing School of Software and Design, a Colorado Non-Profit Organization.</p>
+  <p><span>For more information on courses and how to enroll visit <a href="https://turing.edu">Turing.edu</a>.</span></p>
+</footer>

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,7 +1,7 @@
 <nav role="navigation">
   <ul class="nav-links">
     <li>
-      <a href="https://curriculum.turing.edu/" class="home-logo-link">
+      <a href="https://turing.edu/" class="home-logo-link">
         <img
           src="/assets/icons/TuringSchool_LogoMark_Gray.png"
           alt="Turing School of Software and Design logo"

--- a/_sass/home-page.scss
+++ b/_sass/home-page.scss
@@ -33,6 +33,25 @@
     letter-spacing: -5px;
   }
 
+  span {
+    font-family: 'Helvetica Neue', sans-serif;
+    font-size: 1.1em;
+  }
+
+  div {
+    margin: 0px 0px 0px 90px;
+  }
+
+  a {
+    color: white;
+    border-color: white;
+  }
+
+  a:hover {
+    color: #F9AE04;
+    border-color: #F9AE04;
+  }
+  
   p {
     font-family: 'Helvetica Neue', sans-serif;
     font-size: 1.1em;

--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@ title: Turing Curriculum
 <section class="splash">
   <div class="splash-text">
     <h1>Turing Curriculum</h1>
+    <div><span>For more information on courses and how to enroll visit <a href="https://turing.edu">Turing.edu</a></span>
+    </div>
+    <a href="https://turing.edu/" class="home-logo-link">
   </div>
 </section>
 


### PR DESCRIPTION
# Curriculum PR Template

### Does this PR close any issues?
No current issue but based on Google Analytics people were finding themselves on our curriculum pages self-teaching, so this PR adds subtle marketing lingo. This way people can find themselves on Turing.edu. 

### Description

The logo in the top right corner now leads to Turing.edu because the homepage/landing page is only a still image.

Added `For more information on courses and how to enroll visit Turing.edu` - Turing.edu has a hover state
<img width="1123" alt="Screenshot 2024-09-14 at 10 13 01" src="https://github.com/user-attachments/assets/a7388be9-4280-47dd-82e1-c59bec064c98">

Added same as above to footer for all curriculum pages
<img width="1363" alt="Screenshot 2024-09-16 at 18 15 18" src="https://github.com/user-attachments/assets/5423eab8-aacf-4ad4-a8e9-086304a25a75">

### What questions do you have/what do you want feedback on? (optional)

