### PR TITLE
Add Cors workshopto lesson list

### DIFF
--- a/module3/lessons/index.md
+++ b/module3/lessons/index.md
@@ -20,7 +20,6 @@ title: Module 3 - Lessons
 * [Intro To Accessibility](./intro-to-a11y)
 * [Network Requests - Fetch](./network_requests)  
 <!-- * [Intro to Cypress Testing](.) -->
-<!-- * [CORS Workshop](.) -->
 <!-- * [FE Error Handling](.) -->
 <!-- * [Responsiveness - Mobile Design using Bootstrap](.) -->
 <!-- * [Async JavaScript](.) -->
@@ -28,6 +27,7 @@ title: Module 3 - Lessons
 
 ## Fullstack Web Development
 * [Intro to Service-Oriented Architecture](./intro_to_soa)
+* [CORS Workshop](https://github.com/turingschool-examples/whats_going_on_with_cors)
 
 ## Professional Development
 * [Mod 3 PD Curriculum](../pd/)


### PR DESCRIPTION
# Curriculum PR Template

### Does this PR close any issues?
Closes #202 

### Description
Adds a list to the Cors Workshop to lesson index page. The workshop/lesson itself is contained in the readme of the repo for this workshop.

### What questions do you have/what do you want feedback on? (optional)
As noted above, the actual lesson content is in the readme for the [workshop repo](https://github.com/turingschool-examples/whats_going_on_with_cors). It was already fairly well set up for a full stack program and it literally walks through solving a cors issue in a full stack app. Eyes are welcome if you'd like to take a peek at the content. The only pieces I adapted were those that referenced "the other program".
