### PR TITLE
Try img tag for broken image

### DIFF
--- a/module3/lessons/react_ideabox.md
+++ b/module3/lessons/react_ideabox.md
@@ -163,7 +163,8 @@ Let's start building out our App component.
 
 Let's figure out what should be a component in our app.
 
-![IdeaBox wireframe](../../../assets/images/lessons/ideaBox/IdeaBox-Browser.png)
+<img src="../../assets/images/lessons/ideabox/IdeaBox-wireframe.png">
+<!-- ![IdeaBox wireframe](../../../assets/images/lessons/ideaBox/IdeaBox-Browser.png) -->
 
 - We have an App component. That should probably hold onto our list of ideas.  
 


### PR DESCRIPTION
Some images are broken in the ideabox tutorial despite working when running locally with `bundle exec jekyll serve --incremental`.

Trying with an <img> tag to see if that fixes it