### PR TITLE
Async pd 4

### DIFF
--- a/module4/lessons/index.md
+++ b/module4/lessons/index.md
@@ -13,6 +13,7 @@ title: Module 4 - Lessons
 ### Career and Professional Development Lessons
 - [Analyzing Tech Challenges](./analyzing_tech_challenges)
 - [Art of the Graceful Exit](./art_of_the_graceful_exit)
+- [Digital Organizing For Your Job Search](../pd/lessons/digital_organizing_job_search)
 
 
 ### Additional Lesson Resources

--- a/module4/lessons/index.md
+++ b/module4/lessons/index.md
@@ -14,6 +14,8 @@ title: Module 4 - Lessons
 - [Analyzing Tech Challenges](./analyzing_tech_challenges)
 - [Art of the Graceful Exit](./art_of_the_graceful_exit)
 - [Digital Organizing For Your Job Search](../pd/lessons/digital_organizing_job_search)
+- [Getting Visible on Social Media](../pd/lessons/getting_visible_social_media)
+- [LinkedIn Challenge](../pd/lessons/linkedin_challenge.md)
 
 
 ### Additional Lesson Resources

--- a/module4/lessons/index.md
+++ b/module4/lessons/index.md
@@ -15,7 +15,7 @@ title: Module 4 - Lessons
 - [Art of the Graceful Exit](./art_of_the_graceful_exit)
 - [Digital Organizing For Your Job Search](../pd/lessons/digital_organizing_job_search)
 - [Getting Visible on Social Media](../pd/lessons/getting_visible_social_media)
-- [LinkedIn Challenge](../pd/lessons/linkedin_challenge.md)
+- [LinkedIn Challenge](../pd/lessons/linkedin_challenge)
 
 
 ### Additional Lesson Resources

--- a/module4/pd/lessons/digital_organizing_job_search.md
+++ b/module4/pd/lessons/digital_organizing_job_search.md
@@ -1,0 +1,30 @@
+---
+layout: page
+title: Digital Organizing For Your Job Search
+module: 4
+---
+
+## Starting Strong
+
+Digital organizing and decluttering can reduce stress and feelings of overwhelm that can block our success, enhancing our productivity and overall well-being. Let's begin Mod 4 by organizing and decluttering our digital files, inboxes, resources, and other digital assets! 
+
+### Digital Organization - Learn
+
+What does digital organization look like? How can I get started?  
+
+Use these video resources:
+- [How to Declutter Your Mind with a Brain Dump](https://www.youtube.com/watch?v=Jqd4Ocex8CQ) (3 mins)
+- [Digital Minimalism by Cal Newport, a Visual Summary](https://www.youtube.com/watch?v=sJdZ7kmA2QQ) (11 mins)
+- [21 Step Guide to Organizing Your Digital Life](https://www.youtube.com/watch?v=fUZxNKTsBy8) (14 mins)
+
+### Digital Organization - Implement
+
+Use these prompts and tasks to guide your digital organization and decluttering process:  
+
+- What applications do you use the most in your day-to-day? Are they easily and readily accessible for you?
+- Experiment with ChatGPT! Try a prompt like: "Pretend to be Japanese organizing consultant Marie Kondo. Help me organize and declutter my digital environment." You can even give more specifics if there is an area of your environment you're trying to focus on.
+- What doesn't need to be front and center in your digital space? What could be housed elsewhere? 
+- Do you have the things you need backed up? Where do you save and store important information?
+- Do you currently have a Job Hunt Tracker? Has it helped so far? 
+  - If you don't currently have a Job Hunt Tracker, try one now: 
+   ex. - [Hunter Job Tracker](https://huntr.co/), [Notion Job Application Tracking Templates](https://www.notion.so/templates/category/job-application-tracking)

--- a/module4/pd/lessons/digital_organizing_job_search.md
+++ b/module4/pd/lessons/digital_organizing_job_search.md
@@ -3,12 +3,12 @@ layout: page
 title: Digital Organizing For Your Job Search
 module: 4
 ---
-
-## Starting Strong
+<!-- 
+## Starting Strong -->
 
 Digital organizing and decluttering can reduce stress and feelings of overwhelm that can block our success, enhancing our productivity and overall well-being. Let's begin Mod 4 by organizing and decluttering our digital files, inboxes, resources, and other digital assets! 
 
-### Digital Organization - Learn
+## Digital Organization - Learn
 
 What does digital organization look like? How can I get started?  
 
@@ -17,7 +17,7 @@ Use these video resources:
 - [Digital Minimalism by Cal Newport, a Visual Summary](https://www.youtube.com/watch?v=sJdZ7kmA2QQ) (11 mins)
 - [21 Step Guide to Organizing Your Digital Life](https://www.youtube.com/watch?v=fUZxNKTsBy8) (14 mins)
 
-### Digital Organization - Implement
+## Digital Organization - Implement
 
 Use these prompts and tasks to guide your digital organization and decluttering process:  
 

--- a/module4/pd/lessons/getting_visible_social_media.md
+++ b/module4/pd/lessons/getting_visible_social_media.md
@@ -1,0 +1,75 @@
+---
+layout: page
+title: Getting Visible on Social Media
+module: 4
+---
+
+## Social Media Visibility
+Social media is a very effective way to connect and build your network. Use this time to get visible through things like posting content, liking and commenting on meaningful conversations, and connecting with influencers in your field. 
+<!-- You'll choose between LEARNING or TRYING to get visible on social media. -->
+
+
+## Learn
+
+How does social media fit into my job search? What does activity or engagement look like on social media? 
+
+<section class="call-to-action">
+### LinkedIn and Blogging
+
+Take a look at some alumni Linkedin profiles to see examples of what activity can look like on social media:
+
+["Ozzie" Osmonson](https://www.linkedin.com/in/ozzie-osmonson/) on LinkedIn  
+[Nicole Gooden](https://www.linkedin.com/in/nicolemgooden/) on LinkedIn
+
+**Read these articles:**
+
+* [2 Reasons Blogging is the "New" Cover Letter](https://www.linkedin.com/pulse/2-reasons-blogging-new-cover-letter-j-t-o-donnell/)
+* [My First Technical Interview](https://stellabonnie.wordpress.com/2020/08/28/my-first-technical-interview/) - Stella Bonnie (2003 Turing Alum) 
+* [Surgical Neurophysiologist Turned Software Engineer](https://alex-desjardins.medium.com/surgical-neurophysiologist-turned-software-engineering-heres-my-story-6c2248aab4db) - Alex Desjardins (2006 Turing Alum) 
+* [Understanding the Javascript Interpreter](https://javascript.plainenglish.io/the-javascript-interpreter-b17d3397ba04) - Joe Haefling (2003 Turing Alum) 
+</section>
+
+## Do
+
+Take some time to try getting visible on social media.
+
+<section class="call-to-action">
+
+### Engage, Repost, Post
+  - Comment, like, and repost!
+    - These are all forms of engagement on social media and contribute to your being visible 
+  - Draft a post for social media
+    - This could be anything from a blog post to an Instagram Reel
+    - Feeling hesitant about posting on Linkedin right now? Lean into what platforms feel comfortable for you!
+  - Have you tried utilizing ChatGPT to come up with ideas or assist with writing?
+    - Check out [this video](https://www.youtube.com/watch?v=oaBjZ7_qpSM) (7 mins) for recommendations on how to get started
+
+</section>
+
+<section class="call-to-action">
+
+### Community Connection
+
+**Another great way to get visible is by getting involved in a community or connecting/following others.**  
+
+* Follow other devs.  Engage with them online.
+* Join groups and communities - online and in person!
+
+<br>
+
+**Meetup, Facebook, LinkedIn, Discord, and Slack are all great groups for growing your network!**  
+
+Take a look at these tech communities:  
+* [Remote Work Communities](https://slofile.com/slack/workremotely)
+* [Product Management Slack Community - Mind the Product](https://www.mindtheproduct.com/product-management-slack-community/)
+* [Fairy God Boss](https://fairygodboss.com)
+* [Colorado Tech Discord Community](https://coloradotech.community/)
+* [Denver Tech Talk Slack Community](https://denvertechtalk.com/)
+* [A11y Accessibility Slack Community](https://accessibility.github.io/a11yslack/)
+
+More resources to help you find additional tech communities:
+* Find public slack communities on [Slofile](https://slofile.com/)
+* [List of best 50 LinkedIn Groups/Community for DevOps...and Software Engineers](https://www.devopsschool.com/blog/list-of-best-50-linkedin-groups-community-for-devops-cloud-containers-technology-devops-engineers-and-software-engineers/)
+* Check out [this list](https://standuply.com/slack-chat-groups) from Standuply
+
+</section>

--- a/module4/pd/lessons/linkedin_challenge.md
+++ b/module4/pd/lessons/linkedin_challenge.md
@@ -1,0 +1,20 @@
+---
+layout: page
+title: LinkedIn Challenge
+module: 4
+---
+
+## CareerFlow Competition!
+
+### Instructions
+
+* Install the [Careerflow Chrome Extension](https://chromewebstore.google.com/detail/careerflow-ai-job-applica/iadokddofjgcgjpjlfhngclhpmaelnli?pli=1)
+* Go to your Linkedin profile and click the blue box with a "C" in it on the right-hand side of the page
+* Make the recommended changes to your profile to improve it - you have until 2PM MT to get your scores in
+* Tally up the scores of each team member and average them.
+
+The team spokesperson will DM your instructor(s) with your individual AND group's average score. **Scores must be submitted by 2PM MST!**  
+
+The team with the highest average overall score will be the winners! 🎉
+
+We will be creating a social media spotlight for the winning team members.  🔦

--- a/module4/pd/lessons/linkedin_challenge.md
+++ b/module4/pd/lessons/linkedin_challenge.md
@@ -10,11 +10,7 @@ module: 4
 
 * Install the [Careerflow Chrome Extension](https://chromewebstore.google.com/detail/careerflow-ai-job-applica/iadokddofjgcgjpjlfhngclhpmaelnli?pli=1)
 * Go to your Linkedin profile and click the blue box with a "C" in it on the right-hand side of the page
-* Make the recommended changes to your profile to improve it - you have until 2PM MT to get your scores in
-* Tally up the scores of each team member and average them.
+* Make the recommended changes to your profile to improve it
+* Submit your score on the intermission work submission form
 
-The team spokesperson will DM your instructor(s) with your individual AND group's average score. **Scores must be submitted by 2PM MST!**  
-
-The team with the highest average overall score will be the winners! 🎉
-
-We will be creating a social media spotlight for the winning team members.  🔦
+We will be creating a social media spotlight for the highest scoring students.  🔦


### PR DESCRIPTION
This PR closes issue #319 

### Description
- Creates a lesson page in the curriculum site for all three Mod 4 Async PD sessions.
  - Digital organizing for your job search
  - Getting visible on social media
  - Linkedin Challenge
- Confirms all links are working


### What questions do you have/what do you want feedback on? (optional) 
I still need to update the Mod 4 calendar to remove instructions from each event and simply link the lessons.
However, it doesn't look like any of these lessons are on the calendar, they've been replaced with Dev Discovery sessions.  Are we keeping these async sessions as well?


